### PR TITLE
Add missing symbolic folder icons to places

### DIFF
--- a/Kaze-dark/24x24/places/folder.svg
+++ b/Kaze-dark/24x24/places/folder.svg
@@ -1,0 +1,16 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_3017_2252)">
+<mask id="mask0_3017_2252" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="0" y="0" width="24" height="24">
+<path d="M24 0H0V24H24V0Z" fill="white"/>
+</mask>
+<g mask="url(#mask0_3017_2252)">
+<path d="M4 11.5V18C4 19.1046 4.89543 20 6 20H18C19.1046 20 20 19.1046 20 18V9.5C20 8.94772 19.5523 8.5 19 8.5H11.8284C11.298 8.5 10.7893 8.71071 10.4142 9.08579L9.58579 9.91421C9.21071 10.2893 8.70201 10.5 8.17157 10.5H5C4.44772 10.5 4 10.9477 4 11.5Z" stroke="#DDDDDD" stroke-width="1.2" stroke-linecap="round"/>
+<path d="M5 10.5V6C5 4.89543 5.89543 4 7 4H9.17157C9.70201 4 10.2107 4.21071 10.5858 4.58579L11.4142 5.41421C11.7893 5.78929 12.298 6 12.8284 6H17C18.1046 6 19 6.89543 19 8V8.5" stroke="#DDDDDD" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</g>
+<defs>
+<clipPath id="clip0_3017_2252">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/Kaze-light/24x24/places/folder.svg
+++ b/Kaze-light/24x24/places/folder.svg
@@ -1,0 +1,11 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_929_207)">
+<path d="M4 11.5V18C4 19.1046 4.89543 20 6 20H18C19.1046 20 20 19.1046 20 18V9.5C20 8.94772 19.5523 8.5 19 8.5H11.8284C11.298 8.5 10.7893 8.71071 10.4142 9.08579L9.58579 9.91421C9.21071 10.2893 8.70201 10.5 8.17157 10.5H5C4.44772 10.5 4 10.9477 4 11.5Z" stroke="#111111" stroke-width="1.2" stroke-linecap="round"/>
+<path d="M5 10.5V6C5 4.89543 5.89543 4 7 4H9.17157C9.70201 4 10.2107 4.21071 10.5858 4.58579L11.4142 5.41421C11.7893 5.78929 12.298 6 12.8284 6H17C18.1046 6 19 6.89543 19 8V8.5" stroke="#111111" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_929_207">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>


### PR DESCRIPTION
Without a file named folder.svg in places generic folders added to Places are using colored version of the icon. This pull request brings it in line with other symbolic icons. folder.svg was generated from existing inode-directory-symbolic.svg file in {light, dark} variant of the theme.